### PR TITLE
Add missing plotly import

### DIFF
--- a/vc_plot_sensor_data.py
+++ b/vc_plot_sensor_data.py
@@ -24,6 +24,7 @@ try:
         DEFAULT_DPI,          # dots‑per‑inch for pixel conversion
     )
     import plotly.graph_objects as go
+    import plotly
 except ImportError as e:
     logger.error(f"❌ Import error: {e}")
     logger.error("Make sure vc_analyzer_endaq.py, vc_config.py, and the 'plotly' + 'kaleido' libs are installed.")


### PR DESCRIPTION
## Summary
- ensure the Plotly package is imported so utils is accessible

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: SyntaxError in flask_server.py)*

------
https://chatgpt.com/codex/tasks/task_e_683f72593b208320a8667e194f910c8d