### PR TITLE
Add release build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ pip install -r requirements.txt
 3. View the generated interactive report in your browser and optionally export a PDF.
 4. Check `user_guide.html` for a more detailed walkthrough of features.
 
+## Build a Release
+
+Create a production-ready bundle and generate a clean `release/` directory with:
+
+```bash
+npm run release -- --zip
+```
+
+This runs the Electron build, strips development files and packages the output as `release.zip`.
+
 ## Testing
 
 Run the Python test suite with `pytest`:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start-electron": "electron .",
     "prebuild": "rm -rf dist/ python-env/",
     "build": "electron-builder && node build/bundle-python.js",
+    "release": "node scripts/release.js",
     "postinstall": "electron-builder install-app-deps",
     "publish": "npm run prebuild && electron-builder -p always && node build/bundle-python.js",
     "lint": "eslint .",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,89 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit' });
+}
+
+function removeDevFiles(dir) {
+  for (const item of fs.readdirSync(dir)) {
+    const full = path.join(dir, item);
+    const stat = fs.statSync(full);
+    if (stat.isDirectory()) {
+      if (["tests", "__tests__", "scripts", ".vscode"].includes(item)) {
+        fs.rmSync(full, { recursive: true, force: true });
+        continue;
+      }
+      removeDevFiles(full);
+    } else {
+      if (/\.spec\.js$/.test(item) || /\.test\.js$/.test(item) || /\.ts$/.test(item)) {
+        fs.rmSync(full, { force: true });
+      }
+    }
+  }
+}
+
+function copyDir(src, dest) {
+  if (!fs.existsSync(src)) return;
+  fs.mkdirSync(dest, { recursive: true });
+  for (const item of fs.readdirSync(src)) {
+    const srcPath = path.join(src, item);
+    const destPath = path.join(dest, item);
+    const stat = fs.statSync(srcPath);
+    if (stat.isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else {
+      fs.mkdirSync(path.dirname(destPath), { recursive: true });
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+function copy(src, dest) {
+  if (!fs.existsSync(src)) return;
+  const stat = fs.statSync(src);
+  if (stat.isDirectory()) {
+    copyDir(src, dest);
+  } else {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+  }
+}
+
+function cleanPackageJson(destDir) {
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  delete pkg.devDependencies;
+  fs.writeFileSync(path.join(destDir, 'package.json'), JSON.stringify(pkg, null, 2));
+}
+
+function createRelease() {
+  const releaseDir = path.join(process.cwd(), 'release');
+  fs.rmSync(releaseDir, { recursive: true, force: true });
+  fs.mkdirSync(releaseDir);
+
+  const runtimeItems = ['dist', 'index.html', 'main.js', 'assets', 'vibecheck', 'user_guide.html'];
+  runtimeItems.forEach(item => {
+    if (fs.existsSync(item)) copy(item, path.join(releaseDir, item));
+  });
+
+  if (fs.existsSync('README.md')) copy('README.md', path.join(releaseDir, 'README.md'));
+  if (fs.existsSync('LICENSE')) copy('LICENSE', path.join(releaseDir, 'LICENSE'));
+
+  cleanPackageJson(releaseDir);
+  removeDevFiles(releaseDir);
+}
+
+function zipRelease() {
+  run('zip -r release.zip release');
+}
+
+function main() {
+  run('npm run build');
+  createRelease();
+  if (process.argv.includes('--zip')) {
+    zipRelease();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add build `release` script to package.json
- document release workflow in README
- implement `scripts/release.js` to create a production bundle

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_683f8d2828bc8320a5841115d3a53d0f